### PR TITLE
Add test-utils feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "tesseral-axum"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseral-axum"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 description = "Tesseral SDK for Axum"
 license = "MIT"
@@ -23,3 +23,6 @@ regex = "1"
 [[example]]
 name = "hello_world"
 path = "examples/hello_world.rs"
+
+[features]
+test-utils = []


### PR DESCRIPTION
We need to test our HTTP handlers but currently there is no way to construct an `Auth` struct manually. I have added a feature flag that enables creating mock access token credentials for use in unit tests.

Let me know if you prefer a different approach, or feel free to make changes to the implementation yourself.