### PR TITLE
Remove dbg! print from Authenticator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "tesseral-axum"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseral-axum"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 description = "Tesseral SDK for Axum"
 license = "MIT"

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -135,7 +135,6 @@ impl Authenticator {
             let access_token_claims =
                 authenticate_access_token(keys, now_unix_seconds as i64, &credentials)
                     .ok_or(AuthenticateError::Unauthorized)?;
-            dbg!(&access_token_claims);
             return Ok(Auth {
                 data: AuthData::AccessToken(AccessTokenData {
                     access_token: credentials,


### PR DESCRIPTION
There's a leftover debug print for the access token claims which pollutes our logs. I've removed it in this PR, but if the intention was to include this for debugging, I think using a crate like `log` or `tracing` instead is the right approach so users can set the log level to remove the print if needed.